### PR TITLE
Add tool-tips to pertinent areas using hint.css package

### DIFF
--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -94,6 +94,7 @@ sidebar-tabular@0.0.1
 spacebars@1.0.7
 spacebars-compiler@1.0.7
 standard-minifiers@1.0.2
+stevenn:hintcss@0.0.1
 styles-base@0.0.1
 stylus@2.511.1
 templating@1.1.5

--- a/app/packages/sidebar-main/main.styl
+++ b/app/packages/sidebar-main/main.styl
@@ -1,5 +1,6 @@
 @import 'nib'
-@import '{styles-base}/variables.styl'
+@import '{styles-base}/tooltips'
+@import '{styles-base}/variables'
 
 .logo
   background url("../../../images/logo.svg") no-repeat

--- a/app/packages/sidebar-main/main_sidebar.jade
+++ b/app/packages/sidebar-main/main_sidebar.jade
@@ -3,19 +3,36 @@ template(name='mainSidebar')
     // Nav tabs
     .sidebar--tab-container
       ul.sidebar--tabs.list-unstyled
-        li.sidebar--collapse.large(class="{{#unless sideBarOpen}} off-canvas {{/unless}}" role='tab')
+        li.sidebar--collapse.large.hint--right.hint--rounded(
+          class="{{#unless sideBarOpen}} off-canvas {{/unless}}"
+          role='tab'
+          data-hint="{{#if sideBarOpen}}Close {{else}} Open {{/if}} Menu")
           i.fa.fa-chevron-circle-left
 
-        li.pane-control(class="{{#if tabActive 1}} active {{/if}}" role='tab' data-tab="1")
+        li.pane-control.hint--right.hint--rounded(
+          class="{{#if tabActive 1}} active {{/if}}"
+          role='tab'
+          data-tab="1"
+          data-hint="Search")
           i.fa.fa-search
 
-        li.pane-control(class="{{#if tabActive 3}} active {{/if}}" role="tab" data-tab="3")
+        li.pane-control.hint--right.hint--rounded(
+          class="{{#if tabActive 3}} active {{/if}}"
+          role="tab"
+          data-tab="3"
+          data-hint="Filter Results")
           i.fa.fa-sliders
 
-        li.pane-control(class="{{#if tabActive 4}} active {{/if}}" data-tab="4")
+        li.pane-control.hint--right.hint--rounded(
+          class="{{#if tabActive 4}} active {{/if}}"
+          data-tab="4"
+          data-hint="Map Options")
           i.fa.fa-map-o
 
-        li#sidebar-draw-rectangle-tool(class="{{#if drawing}} active {{/if}}" data-tab="2")
+        li#sidebar-draw-rectangle-tool.hint--right.hint--rounded(
+          class="{{#if drawing}} active {{/if}}"
+          data-tab="2"
+          data-hint="Select Search Area")
           i.fa.fa-object-group
 
         li.help-toggle.large.push-to-btm
@@ -30,10 +47,19 @@ template(name='mainSidebar')
       h1.logo FLIRT
       #mode-toggle.btn-group(data-toggle='buttons')
         label.btn.btn-mode.active
-          input(type='radio', name='mode', data-mode='{{MODE_EXPLORE}}', autocomplete='off', checked='')
+          input(
+            type='radio'
+            name='mode'
+            data-mode='{{MODE_EXPLORE}}'
+            autocomplete='off'
+            checked='')
           |  {{_ "mode.explore" }}
         label.btn.btn-mode
-          input(type='radio', name='mode', data-mode='{{MODE_ANALYZE}}', autocomplete='off')
+          input(
+            type='radio'
+            name='mode'
+            data-mode='{{MODE_ANALYZE}}'
+            autocomplete='off')
           |  {{_ "mode.analyze" }}
 
       #sidebar-search.sidebar--pane(class="{{#if paneActive 1}} active {{/if}}")

--- a/app/packages/sidebar-main/package.js
+++ b/app/packages/sidebar-main/package.js
@@ -13,7 +13,8 @@ Package.onUse(function(api) {
     'mquandalle:jade@0.4.9',
     'stylus',
     'reactive-var',
-    'sidebar'
+    'sidebar',
+    'stevenn:hintcss'
   ], 'client');
 
   api.addFiles([

--- a/app/packages/sidebar-tabular/main.styl
+++ b/app/packages/sidebar-tabular/main.styl
@@ -1,0 +1,13 @@
+@import 'nib'
+@import '{styles-base}/tooltips'
+
+.hint-tabular
+  position absolute
+  height 100%
+  width 100%
+  &.hint:before
+  &::before
+    border-right transparent
+  &.hint--right:before
+    margin-right 22px
+    margin-left 0px

--- a/app/packages/sidebar-tabular/package.js
+++ b/app/packages/sidebar-tabular/package.js
@@ -13,11 +13,13 @@ Package.onUse(function(api) {
     'mquandalle:jade@0.4.9',
     'stylus',
     'reactive-var',
-    'sidebar'
+    'sidebar',
+    'stevenn:hintcss'
   ], 'client');
 
 
   api.addFiles([
+    'main.styl',
     'tabular_sidebar.jade',
     'tabular_sidebar.coffee',
   ], 'client');

--- a/app/packages/sidebar-tabular/tabular_sidebar.jade
+++ b/app/packages/sidebar-tabular/tabular_sidebar.jade
@@ -1,6 +1,9 @@
 template(name='tabularSidebar')
   #tableSidebar.sidebar-tabular(class="{{#unless open}} off-canvas {{/unless}}")
     .sidebar--table--tab(class="{{#unless open}} off-canvas {{/unless}}")
+      span(
+        class="{{#unless open}} hint--left hint--rounded hint-tabular {{/unless}}"
+        data-hint="Tabular Data")
       i.fa.fa-angle-double-left.fa-white-arrow
       i.fa.fa-table.fa-white-table
     .sidebar--content

--- a/app/packages/sidebar/main.styl
+++ b/app/packages/sidebar/main.styl
@@ -1,5 +1,5 @@
 @import 'nib'
-@import '{styles-base}/variables.styl'
+@import '{styles-base}/variables'
 @import 'variables.import'
 @import 'base.import'
 @import 'tabular.import'

--- a/app/packages/styles/package.js
+++ b/app/packages/styles/package.js
@@ -10,4 +10,5 @@ Package.onUse(function(api) {
   api.use('stylus');
 
   api.addFiles('variables.styl', 'client', {isImport: true});
+  api.addFiles('tooltips.styl', 'client', {isImport: true});
 });

--- a/app/packages/styles/tooltips.styl
+++ b/app/packages/styles/tooltips.styl
@@ -1,0 +1,33 @@
+@import '{styles-base}/variables'
+$tooltip-BG = alpha($tabs-bg, 95%)
+
+.hint:after
+[data-hint]::after
+  background $tooltip-BG
+  text-shadow 0 1px 0px alpha($primary-d, 70%)
+  box-shadow none
+
+.hint:before
+.hint:after
+[data-hint]:before
+[data-hint]:after
+  transition: 0.15s ease-in-out
+
+.hint:before
+[data-hint]::before
+  border-right-color $tooltip-BG
+
+.hint--right:before
+  margin-left -12px
+
+.hint--right:before
+.hint--right:after
+  left calc(100% + 4px)
+
+.hint--left:before
+.hint--left:after
+  right calc(100% + 4px)
+
+.hint--left:before
+  margin-right -6px
+  border-left-color $tooltip-BG


### PR DESCRIPTION
I've been meaning to implement this for a while.
Uses hint.css which offers pure css tooltips.

<img width="299" alt="screen shot 2016-06-07 at 10 44 48 am" src="https://cloud.githubusercontent.com/assets/4105343/15862195/e5e2bf30-2c9c-11e6-9066-0a6cfed353de.png">
