### PR TITLE
fix discontinued mapquest layer

### DIFF
--- a/app/packages/core/core.coffee
+++ b/app/packages/core/core.coffee
@@ -39,17 +39,11 @@ if Meteor.isClient
           attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
           subdomains: 'abcd'
           maxZoom: 19)
-        MapQuestOpen_OSM = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}',
-          type: 'map'
-          layerName: 'MapQuestOpen_OSM'
-          noWrap: true
-          ext: 'jpg'
-          subdomains: '1234')
         Esri_WorldImagery = L.tileLayer('http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
           layerName: 'Esri_WorldImagery'
           noWrap: true)
 
-        baseLayers = [OpenStreetMap, Esri_WorldImagery, MapQuestOpen_OSM]
+        baseLayers = [OpenStreetMap, Esri_WorldImagery]
         element = 'grits-map'
         height = window.innerHeight
         options = {


### PR DESCRIPTION
Direct access to the mapquest tile server has been discontinued. 

The mapquest API is only accessible via a script tag with a client key. The script tag is difficult to utilize with meteor, especially since its dependent on leaflet to be loaded first. Since this tile layer wasn't being used as the default layer it was removed. To continue using mapquest would require signing up for a key, creating an atmosphere package, and ensuring the correct loading order with `bevanhunt/leaflet`.

https://www.pivotaltracker.com/story/show/136122465